### PR TITLE
Optional files should be optional

### DIFF
--- a/src/ChimpLab.Extensions.Configuration.Json/JsonConfigurationAbsolutePathExtensions.cs
+++ b/src/ChimpLab.Extensions.Configuration.Json/JsonConfigurationAbsolutePathExtensions.cs
@@ -73,7 +73,15 @@ namespace ChimpLab.Extensions.Configuration
 
             if (provider == null)
             {
-                provider = new PhysicalFileProvider(Path.GetDirectoryName(path));
+                var directoryName = Path.GetDirectoryName(path);
+
+                if(!ShouldDirectoryExist(optional, reloadOnChange) &&
+                   !Directory.Exists(directoryName))
+                {
+                    return builder;
+                }
+
+                provider = new PhysicalFileProvider(directoryName);
                 path = Path.GetFileName(path);
             }
             var source = new JsonConfigurationSource
@@ -85,6 +93,12 @@ namespace ChimpLab.Extensions.Configuration
             };
             builder.Add(source);
             return builder;
+        }
+
+        private static bool ShouldDirectoryExist(bool optional, bool reloadOnChange)
+        {
+            return !optional ||
+                   reloadOnChange;
         }
     }
 }

--- a/tests/ChimpLab.Extensions.Configuration.Json.Tests/JsonConfigurationAbsolutePathExtensionsTests.cs
+++ b/tests/ChimpLab.Extensions.Configuration.Json.Tests/JsonConfigurationAbsolutePathExtensionsTests.cs
@@ -85,6 +85,26 @@ namespace ChimpLab.Extensions.Configuration.Json.Tests
             Assert.Contains("Database", config.AsEnumerable().Select(k => k.Key));
         }
 
+        [Fact]
+        public void AddJsonFileFromAbsolutePath_OptionalWithPathThatDoesNotExist_DoesNotAddFile()
+        {
+            string path = "c:\\this\\directory\\doesnotexist\\file.json";
+            IConfigurationBuilder sut = new ConfigurationBuilder();
+
+            sut.AddJsonFileFromAbsolutePath(path, optional:true);
+
+            Assert.Empty(sut.Sources);
+        }
+
+        [Fact]
+        public void AddJsonFileFromAbsolutePath_OptionalButReloadOnChangeWithPathThatDoesNotExist_ThrowsException()
+        {
+            string path = "c:\\this\\directory\\doesnotexist\\file.json";
+            IConfigurationBuilder sut = new ConfigurationBuilder();
+
+            Assert.Throws<ArgumentException>(() => sut.AddJsonFileFromAbsolutePath(path, optional:true, reloadOnChange: true));
+        }
+
         private T GetValue<T>(IConfigurationSource source, string propName)
         {
             var type = source.GetType();


### PR DESCRIPTION
When you use `AddJsonFileFromAbsolutePath` and the _directory_ you specify does not exist, it will throw an exception, because creating the `PhysicalFileProvider` will attempt to start a `FileSystemWatcher`.

It would probably be nice if optional files don't have this requirement. An exception if made when you require `reloadOnChange`, because in that case you would expect the system to react to the file being created while the application is running, and that simply won't work if the directory doesn't exist (again, because of `FileSystemWatcher`).
